### PR TITLE
fix: persist fetched dividend history as activity events

### DIFF
--- a/api/app/services/broker_sync_service.py
+++ b/api/app/services/broker_sync_service.py
@@ -154,6 +154,38 @@ def sync_portfolio(
     try:
         dividends = client.get_all_dividend_history()
         result.dividends_fetched = len(dividends)
+
+        # Create activity events for recent dividends
+        for dividend in dividends[:20]:  # Only latest 20
+            ticker = (
+                dividend.get("ticker")
+                or dividend.get("instrumentTicker")
+                or dividend.get("symbol")
+                or "?"
+            )
+            amount = (
+                dividend.get("amount")
+                if dividend.get("amount") is not None
+                else dividend.get("netAmount", dividend.get("grossAmount"))
+            )
+            currency = dividend.get("currencyCode") or dividend.get("currency")
+            ex_date = dividend.get("exDividendDate") or dividend.get("paymentDate")
+
+            amount_text = f"Amount: {amount} {currency}" if currency else f"Amount: {amount}"
+            description_parts = [amount_text] if amount is not None else []
+            if ex_date:
+                description_parts.append(f"Date: {ex_date}")
+
+            repo.add_event(
+                event_type="dividend",
+                title=f"Dividend {ticker}",
+                portfolio_id=portfolio_id,
+                description=" | ".join(description_parts) if description_parts else None,
+                metadata={
+                    "dividend_id": dividend.get("id"),
+                    "ticker": ticker,
+                },
+            )
     except Exception as e:
         errors.append(f"Dividend history fetch failed: {e}")
         logger.error("Dividend history error: %s", e)

--- a/api/tests/unit/test_broker_sync_service.py
+++ b/api/tests/unit/test_broker_sync_service.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+from app.services import broker_sync_service
+
+
+class DummyClient:
+    def get_portfolio_positions(self):
+        return []
+
+    def get_account_cash(self):
+        return {"total": 100, "free": 50, "invested": 50}
+
+    def get_account_info(self):
+        return {"currencyCode": "USD"}
+
+    def get_all_order_history(self):
+        return []
+
+    def get_all_dividend_history(self):
+        return [
+            {
+                "id": "div-1",
+                "ticker": "AAPL",
+                "amount": 1.23,
+                "currencyCode": "USD",
+                "exDividendDate": "2026-03-01",
+            }
+        ]
+
+
+class DummyRepo:
+    instances = []
+
+    def __init__(self, session):
+        self.events = []
+        DummyRepo.instances.append(self)
+
+    def upsert_positions(self, portfolio_id, position_rows, synced_at):
+        return 0
+
+    def delete_stale_positions(self, portfolio_id, current_tickers):
+        return 0
+
+    def upsert_account_snapshot(self, portfolio_id, cash_data, synced_at):
+        return None
+
+    def add_event(self, **kwargs):
+        self.events.append(kwargs)
+
+
+class DummySession:
+    def commit(self):
+        return None
+
+
+def test_sync_portfolio_persists_dividend_events(monkeypatch):
+    monkeypatch.setattr(broker_sync_service, "PortfolioRepository", DummyRepo)
+    monkeypatch.setattr(
+        broker_sync_service,
+        "_map_t212_ticker_to_yfinance",
+        lambda ticker, session: None,
+    )
+
+    DummyRepo.instances.clear()
+
+    result = broker_sync_service.sync_portfolio(
+        client=DummyClient(),
+        portfolio_id="portfolio-1",
+        session=DummySession(),
+    )
+
+    repo = DummyRepo.instances[0]
+
+    assert result.dividends_fetched == 1
+    dividend_events = [e for e in repo.events if e["event_type"] == "dividend"]
+    assert len(dividend_events) == 1
+    assert dividend_events[0]["title"] == "Dividend AAPL"
+    assert dividend_events[0]["metadata"]["dividend_id"] == "div-1"


### PR DESCRIPTION
## Bug
Fixes #318. `sync_portfolio()` fetched dividend history and reported `dividends_fetched`, but never persisted any dividend activity entries.

## Fix
- Added dividend event creation in the dividend sync step (mirroring the order-event behavior)
- Added defensive field mapping for ticker/amount/date/currency from Trading 212 payload variants
- Stored key metadata (`dividend_id`, `ticker`) for traceability
- Added a focused unit test that verifies a fetched dividend is persisted as a `dividend` activity event

## Testing
- `python3 -m py_compile app/services/broker_sync_service.py tests/unit/test_broker_sync_service.py`

Happy to address any feedback.

Greetings, saschabuehrle
